### PR TITLE
Name links similar to other components

### DIFF
--- a/oemoflex/model/model_structure.py
+++ b/oemoflex/model/model_structure.py
@@ -234,7 +234,7 @@ def create_component_element(component_attrs, select_regions, select_links):
     if simple_keys['type'] == 'link':
         # TODO: Check the diverging conventions of '-' and '_' and think about unifying.
         comp_data['region'] = [link.replace('-', '_') for link in select_links]
-        comp_data['name'] = select_links
+        comp_data['name'] = ['-'.join([link, simple_keys['carrier'], simple_keys['tech']]) for link in select_links]
         comp_data['from_bus'] = [link.split('-')[0] + '-' + foreign_keys['from_bus'] for link in select_links]
         comp_data['to_bus'] = [link.split('-')[1] + '-' + foreign_keys['to_bus'] for link in select_links]
 


### PR DESCRIPTION
Until now, links are just named "A-B". This PR renames them to "A-B-electricity-transmission".