### PR TITLE
Include transmission capacities in postprocessed scalars

### DIFF
--- a/oemoflex/model/postprocessing.py
+++ b/oemoflex/model/postprocessing.py
@@ -609,6 +609,10 @@ def run_postprocessing(es):
     # Keep in mind - this has an index of the form (component, None). It is not attributed to a flow
     capacity = filter_by_var_name(scalar_params, 'capacity')
 
+    from_to_capacity = filter_by_var_name(scalar_params, 'from_to_capacity')
+
+    to_from_capacity = filter_by_var_name(scalar_params, 'to_from_capacity')
+
     # Keep in mind - this has an index of the form (component, None). It is not attributed to a flow
     storage_capacity = filter_by_var_name(scalar_params, 'storage_capacity')
 
@@ -672,6 +676,8 @@ def run_postprocessing(es):
         transmission_losses,
         capacity,
         storage_capacity,
+        from_to_capacity,
+        to_from_capacity,
         invested_capacity,
         invested_storage_capacity,
         summed_carrier_costs,


### PR DESCRIPTION
Exogenous transmission capacities are not reported within the scalar results. This PR fixes that.