### PR TITLE
Add explanation for black version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,6 @@ setup(
         "oemof.tabular @ git+https://git@github.com/oemof/oemof-tabular@dev#egg=oemof.tabular",
         "frictionless",
     ],
+    # black version is specified so that each contributor uses the same one
     extras_require={"dev": ["pytest", "black==20.8b1", "coverage", "flake8"]},
 )


### PR DESCRIPTION
This PR resolves #24.

With this PR an explanation to the question in issue https://github.com/rl-institut/oemoflex/issues/24 is added as a comment in `setup.py`.