### PR TITLE
Raise warning when saving DataFramePackage would overwrite existing data

### DIFF
--- a/examples/simple_model.py
+++ b/examples/simple_model.py
@@ -54,7 +54,7 @@ edp.parametrize("electricity-demand-profile", "A-electricity-demand-profile", pr
 edp.parametrize("electricity-demand-profile", "B-electricity-demand-profile", profile)
 
 # save to csv
-edp.to_csv_dir(preprocessed)
+edp.to_csv_dir(preprocessed, overwrite=True)
 
 # add metadata
 edp.infer_metadata()
@@ -88,4 +88,4 @@ results_dp = ResultsDataPackage.from_energysytem(es_restored)
 
 results_dp.set_scenario_name("simple_model")
 
-results_dp.to_csv_dir(postprocessed)
+results_dp.to_csv_dir(postprocessed, overwrite=True)

--- a/oemoflex/model/datapackage.py
+++ b/oemoflex/model/datapackage.py
@@ -60,6 +60,12 @@ class DataFramePackage:
                 "Pass 'overwrite=True' to ignore"
             )
 
+        # if overwrite is True and the path exists, delete any
+        elif overwrite and os.path.exists(destination):
+            import shutil
+
+            shutil.rmtree(destination)
+
         for name, data in self.data.items():
             path = self.rel_paths[name]
 

--- a/oemoflex/model/datapackage.py
+++ b/oemoflex/model/datapackage.py
@@ -50,10 +50,16 @@ class DataFramePackage:
 
         return cls(dir, data, rel_paths)
 
-    def to_csv_dir(self, destination):
+    def to_csv_dir(self, destination, overwrite=False):
         r"""
         Save the DataFramePackage to csv files.
         """
+        if not overwrite and os.listdir(destination):
+            raise UserWarning(
+                "The path is not empty. Might overwrite existing data. "
+                "Pass 'overwrite=True' to ignore"
+            )
+
         for name, data in self.data.items():
             path = self.rel_paths[name]
 

--- a/tests/test_datapackage.py
+++ b/tests/test_datapackage.py
@@ -55,7 +55,7 @@ def test_edp_setup_default():
 
     clean_path(basepath)
 
-    edp.to_csv_dir(basepath)
+    edp.to_csv_dir(basepath, overwrite=True)
 
     check_if_csv_dirs_equal(basepath, defaultpath)
 
@@ -108,12 +108,12 @@ def test_edp_stack_unstack():
 
     clean_path(after)
 
-    edp.to_csv_dir(before)
+    edp.to_csv_dir(before, overwrite=True)
 
     edp.stack_components()
 
     edp.unstack_components()
 
-    edp.to_csv_dir(after)
+    edp.to_csv_dir(after, overwrite=True)
 
     check_if_csv_dirs_equal(before, after)


### PR DESCRIPTION
This PR adds a warning to the method `DataFramePackage.to_csv` that is raised when the target directory is not empty. To write to the directory anyway, the user can explicitly pass `overwrite=True`.