### PR TITLE
Remove capacity constraint from shortage and excess

### DIFF
--- a/oemoflex/model/facade_attrs/excess.csv
+++ b/oemoflex/model/facade_attrs/excess.csv
@@ -5,6 +5,5 @@ type,str,n/a,Type
 carrier,str,n/a,Energy carrier
 tech,str,n/a,Technology
 bus,str,n/a,The bus this component is connected to
-capacity,float,MW,Installed capacity
 marginal_cost,float,Eur/MWh,Marginal cost
 output_parameters,dict,n/a,Optional parameters passed to oemof-solph's output flow

--- a/oemoflex/model/facade_attrs/shortage.csv
+++ b/oemoflex/model/facade_attrs/shortage.csv
@@ -5,6 +5,5 @@ type,str,n/a,Type
 carrier,str,n/a,Energy carrier
 tech,str,n/a,Technology
 bus,str,n/a,The bus this component is connected to
-capacity,float,MW,Installed capacity
 marginal_cost,float,Eur/MWh,Marginal cost
 output_parameters,dict,n/a,Optional parameters passed to oemof-solph's output flow

--- a/tests/_files/default_edp/data/elements/ch4-excess.csv
+++ b/tests/_files/default_edp/data/elements/ch4-excess.csv
@@ -1,3 +1,3 @@
-name,bus,capacity,carrier,marginal_cost,output_parameters,region,tech,type
-A-ch4-excess,A-ch4,,ch4,0,{},A,excess,excess
-B-ch4-excess,B-ch4,,ch4,0,{},B,excess,excess
+name,bus,carrier,marginal_cost,output_parameters,region,tech,type
+A-ch4-excess,A-ch4,ch4,0,{},A,excess,excess
+B-ch4-excess,B-ch4,ch4,0,{},B,excess,excess

--- a/tests/_files/default_edp/data/elements/electricity-curtailment.csv
+++ b/tests/_files/default_edp/data/elements/electricity-curtailment.csv
@@ -1,3 +1,3 @@
-name,bus,capacity,carrier,marginal_cost,output_parameters,region,tech,type
-A-electricity-curtailment,A-electricity,,electricity,0,{},A,curtailment,excess
-B-electricity-curtailment,B-electricity,,electricity,0,{},B,curtailment,excess
+name,bus,carrier,marginal_cost,output_parameters,region,tech,type
+A-electricity-curtailment,A-electricity,electricity,0,{},A,curtailment,excess
+B-electricity-curtailment,B-electricity,electricity,0,{},B,curtailment,excess

--- a/tests/_files/default_edp/data/elements/electricity-shortage.csv
+++ b/tests/_files/default_edp/data/elements/electricity-shortage.csv
@@ -1,3 +1,3 @@
-name,bus,capacity,carrier,marginal_cost,output_parameters,region,tech,type
-A-electricity-shortage,A-electricity,,electricity,,{},A,shortage,shortage
-B-electricity-shortage,B-electricity,,electricity,,{},B,shortage,shortage
+name,bus,carrier,marginal_cost,output_parameters,region,tech,type
+A-electricity-shortage,A-electricity,electricity,,{},A,shortage,shortage
+B-electricity-shortage,B-electricity,electricity,,{},B,shortage,shortage

--- a/tests/_files/default_edp/data/elements/heat-excess.csv
+++ b/tests/_files/default_edp/data/elements/heat-excess.csv
@@ -1,3 +1,3 @@
-name,bus,capacity,carrier,marginal_cost,output_parameters,region,tech,type
-A-heat-excess,A-heat,,heat,0,,A,excess,excess
-B-heat-excess,B-heat,,heat,0,,B,excess,excess
+name,bus,carrier,marginal_cost,output_parameters,region,tech,type
+A-heat-excess,A-heat,heat,0,,A,excess,excess
+B-heat-excess,B-heat,heat,0,,B,excess,excess

--- a/tests/_files/default_edp/data/elements/heat-shortage.csv
+++ b/tests/_files/default_edp/data/elements/heat-shortage.csv
@@ -1,3 +1,3 @@
-name,bus,capacity,carrier,marginal_cost,output_parameters,region,tech,type
-A-heat-shortage,A-heat,,heat,,{},A,shortage,shortage
-B-heat-shortage,B-heat,,heat,,{},B,shortage,shortage
+name,bus,carrier,marginal_cost,output_parameters,region,tech,type
+A-heat-shortage,A-heat,heat,,{},A,shortage,shortage
+B-heat-shortage,B-heat,heat,,{},B,shortage,shortage


### PR DESCRIPTION
Shortage and excess allow to keep problems feasible and should not have a capacity constraint.