### PR TITLE
Features/add investment components

### DIFF
--- a/oemoflex/model/facade_attrs/backpressure.csv
+++ b/oemoflex/model/facade_attrs/backpressure.csv
@@ -10,5 +10,7 @@ heat_bus,str,n/a,The bus for heat output
 capacity,float,MW_el,Installed electric capacity in full extraction mode
 electric_efficiency,float,,Electrical efficiency of the chp unit
 thermal_efficiency,float,,Thermal efficiency of the chp unit
+expandable,boolean,,Capacity can be expanded
+capacity_cost,float,Eur/MW,Annualized costs of capacity expansion
 carrier_cost,float,Eur/MWh,Cost per unit of used fuel
 marginal_cost,float,Eur/MWh_el,Marginal cost per unit of produced electrical output

--- a/oemoflex/model/facade_attrs/extraction.csv
+++ b/oemoflex/model/facade_attrs/extraction.csv
@@ -11,5 +11,7 @@ capacity,float,MW_el,Installed electric capacity in full extraction mode
 electric_efficiency,float,,Electrical efficiency of the chp unit in full backpressure mode
 thermal_efficiency,float,,Thermal efficiency of the chp unit in full backpressure mode
 condensing_efficiency,float,,Electrical efficiency if turbine operates in full extraction mode
+expandable,boolean,,Capacity can be expanded
+capacity_cost,float,Eur/MW,Annualized costs of capacity expansion
 carrier_cost,float,Eur/MWh,Cost per unit of used fuel
 marginal_cost,float,Eur/MWh_el,Marginal cost per unit of produced electrical output

--- a/oemoflex/model/facade_attrs/link.csv
+++ b/oemoflex/model/facade_attrs/link.csv
@@ -7,5 +7,6 @@ tech,str,n/a,Technology
 from_bus,str,n/a,Bus where link starts
 to_bus,str,n/a,Bus where link ends
 capacity,float,MW,Net transfer capacity
+expandable,boolean,,Capacity can be expanded
 capacity_cost,float,Eur/MW,Annualized costs of capacity expansion
 loss,float,unitless,Transmission losses

--- a/oemoflex/model/facade_attrs/link.csv
+++ b/oemoflex/model/facade_attrs/link.csv
@@ -6,7 +6,8 @@ carrier,str,n/a,Energy carrier
 tech,str,n/a,Technology
 from_bus,str,n/a,Bus where link starts
 to_bus,str,n/a,Bus where link ends
-capacity,float,MW,Net transfer capacity
+from_to_capacity,float,MW,Net transfer capacity in defined direction
+to_from_capacity,float,MW,Net transfer capacity opposite to defined direction
 expandable,boolean,,Capacity can be expanded
 capacity_cost,float,Eur/MW,Annualized costs of capacity expansion
 loss,float,unitless,Transmission losses

--- a/tests/_files/default_edp/data/elements/ch4-bpchp.csv
+++ b/tests/_files/default_edp/data/elements/ch4-bpchp.csv
@@ -1,3 +1,3 @@
-name,capacity,carrier,carrier_cost,electric_efficiency,electricity_bus,fuel_bus,heat_bus,marginal_cost,region,tech,thermal_efficiency,type
-A-ch4-bpchp,,ch4,,,A-electricity,A-ch4,A-heat,,A,bpchp,,backpressure
-B-ch4-bpchp,,ch4,,,B-electricity,B-ch4,B-heat,,B,bpchp,,backpressure
+name,capacity,capacity_cost,carrier,carrier_cost,electric_efficiency,electricity_bus,expandable,fuel_bus,heat_bus,marginal_cost,region,tech,thermal_efficiency,type
+A-ch4-bpchp,,,ch4,,,A-electricity,,A-ch4,A-heat,,A,bpchp,,backpressure
+B-ch4-bpchp,,,ch4,,,B-electricity,,B-ch4,B-heat,,B,bpchp,,backpressure

--- a/tests/_files/default_edp/data/elements/ch4-extchp.csv
+++ b/tests/_files/default_edp/data/elements/ch4-extchp.csv
@@ -1,3 +1,3 @@
-name,capacity,carrier,carrier_cost,condensing_efficiency,electric_efficiency,electricity_bus,fuel_bus,heat_bus,marginal_cost,region,tech,thermal_efficiency,type
-A-ch4-extchp,,ch4,,,,A-electricity,A-ch4,A-heat,,A,extchp,,extraction
-B-ch4-extchp,,ch4,,,,B-electricity,B-ch4,B-heat,,B,extchp,,extraction
+name,capacity,capacity_cost,carrier,carrier_cost,condensing_efficiency,electric_efficiency,electricity_bus,expandable,fuel_bus,heat_bus,marginal_cost,region,tech,thermal_efficiency,type
+A-ch4-extchp,,,ch4,,,,A-electricity,,A-ch4,A-heat,,A,extchp,,extraction
+B-ch4-extchp,,,ch4,,,,B-electricity,,B-ch4,B-heat,,B,extchp,,extraction

--- a/tests/_files/default_edp/data/elements/electricity-transmission.csv
+++ b/tests/_files/default_edp/data/elements/electricity-transmission.csv
@@ -1,2 +1,2 @@
-name,capacity,capacity_cost,carrier,expandable,from_bus,loss,region,tech,to_bus,type
-A-B-electricity-transmission,,,electricity,,A-electricity,,A_B,transmission,B-electricity,link
+name,capacity_cost,carrier,expandable,from_bus,from_to_capacity,loss,region,tech,to_bus,to_from_capacity,type
+A-B-electricity-transmission,,electricity,,A-electricity,,,A_B,transmission,B-electricity,,link

--- a/tests/_files/default_edp/data/elements/electricity-transmission.csv
+++ b/tests/_files/default_edp/data/elements/electricity-transmission.csv
@@ -1,2 +1,2 @@
-name,capacity,capacity_cost,carrier,from_bus,loss,region,tech,to_bus,type
-A-B-electricity-transmission,,,electricity,A-electricity,,A_B,transmission,B-electricity,link
+name,capacity,capacity_cost,carrier,expandable,from_bus,loss,region,tech,to_bus,type
+A-B-electricity-transmission,,,electricity,,A-electricity,,A_B,transmission,B-electricity,link


### PR DESCRIPTION
Resolves issue #21 

As addressed in issue https://github.com/rl-institut/oemoflex/issues/39 with this PR investment is now possible for the following components:

* backpressure
* extraction
* link

Still open is investment in reservoir, as it is not yet implemented in the `facades` as mentioned in this [comment](https://github.com/rl-institut/oemoflex/issues/39#issuecomment-1023455908) in issue https://github.com/rl-institut/oemoflex/issues/39.

