### PR TITLE
Switched to omeof.solph v0.4

### DIFF
--- a/oemoflex/model/datapackage.py
+++ b/oemoflex/model/datapackage.py
@@ -4,7 +4,7 @@ import os
 import oemof.tabular.tools.postprocessing as tabular_pp
 import pandas as pd
 from frictionless import Package
-from oemof.outputlib.views import convert_to_multiindex
+from oemof.solph.views import convert_to_multiindex
 
 from oemoflex.model.inferring import infer
 from oemoflex.model.model_structure import create_default_data

--- a/oemoflex/model/postprocessing.py
+++ b/oemoflex/model/postprocessing.py
@@ -4,7 +4,7 @@ import os
 import numpy as np
 import pandas as pd
 
-from oemof.network import Component
+from oemof.network.network import Component
 from oemof.solph import Bus, EnergySystem
 
 

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,6 @@ setup(
     install_requires=[
         "pyyaml",
         "pandas",
-        "pyomo",
-        "pyutilib",
         "oemof.tabular @ git+https://git@github.com/oemof/oemof-tabular@dev#egg=oemof.tabular",
         "frictionless",
     ],

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ setup(
     install_requires=[
         "pyyaml",
         "pandas",
-        "pyomo<5.6.9",
-        "pyutilib<6.0.0",
+        "pyomo",
+        "pyutilib",
         "oemof.tabular @ git+https://git@github.com/oemof/oemof-tabular@dev#egg=oemof.tabular",
         "frictionless",
     ],

--- a/tests/test_datapackage.py
+++ b/tests/test_datapackage.py
@@ -1,7 +1,7 @@
 import os
 from shutil import rmtree
 
-from oemof.tools.helpers import extend_basic_path
+from oemof.solph.helpers import extend_basic_path
 
 from oemoflex.model.datapackage import DataFramePackage, EnergyDataPackage
 from oemoflex.tools.helpers import check_if_csv_dirs_equal


### PR DESCRIPTION
Dependency-chain is now like:
- oemof.solph@v0.4 (currently to PR fix/link_inputs which shall be merged into v0.4)
- oemof.tabular@dev (using omeof.solph v0.4)
- oemoflex pointing to oemof.tabular@dev
- 
Had to fix imports for oemof.solph and oemof.network.
Tests are running fine - but as there are only few tests, I don't know if everything is okay.
Could you review @jnnr ?