### PR TITLE
Fix filtering of component-to-component flows

### DIFF
--- a/oemoflex/model/postprocessing.py
+++ b/oemoflex/model/postprocessing.py
@@ -4,7 +4,6 @@ import os
 import numpy as np
 import pandas as pd
 
-from oemof.network.network import Component
 from oemof.solph import Bus, EnergySystem
 
 
@@ -64,7 +63,7 @@ def drop_component_to_component(series):
     component_to_component_ids = [
         id
         for id in series.index
-        if isinstance(id[0], Component) and isinstance(id[1], Component)
+        if not isinstance(id[0], Bus) and not isinstance(id[1], Bus)
     ]
 
     result = _series.drop(component_to_component_ids)


### PR DESCRIPTION
GenericStorage stopped being a component in oemof.solph v0.4. Postprocessing relies on flows that go from component to bus or from bus to component. In some special applications, there may be flows that connect components directly. These are filtered by checking the type. The filtering has been fixed: If both entries in the oemof results tuple are not Busses, the flow is dropped from the results.