### PR TITLE
Investment cost for capacities are postprocessed

### DIFF
--- a/oemoflex/model/postprocessing.py
+++ b/oemoflex/model/postprocessing.py
@@ -658,25 +658,40 @@ def run_postprocessing(es):
 
     ep_costs = filter_by_var_name(scalar_params, "investment_ep_costs")
     ep_costs.index = ep_costs.reset_index(level=2, drop=True).index.map(
-        lambda x: (x[0].label, x[1].label if not isinstance(x[1], float) else x[1]))
+        lambda x: (x[0].label, x[1].label if not isinstance(x[1], float) else x[1])
+    )
 
     invested_capacity_costs = invested_capacity.copy()
-    invested_capacity_costs.index = invested_capacity.reset_index(level=2, drop=True).index.map(
-        lambda x: (x[0].label, x[1].label if not isinstance(x[1], float) else x[1]))
-    invested_capacity_costs = invested_capacity_costs.multiply(ep_costs.reindex(invested_capacity_costs.index))
+    invested_capacity_costs.index = invested_capacity.reset_index(
+        level=2, drop=True
+    ).index.map(
+        lambda x: (x[0].label, x[1].label if not isinstance(x[1], float) else x[1])
+    )
+    invested_capacity_costs = invested_capacity_costs.multiply(
+        ep_costs.reindex(invested_capacity_costs.index)
+    )
     invested_capacity_costs.index = invested_capacity.index
     invested_capacity_costs = invested_capacity_costs.dropna()
     invested_capacity_costs.index = invested_capacity_costs.index.set_levels(
-        invested_capacity_costs.index.levels[2] + "_costs", level=2)
+        invested_capacity_costs.index.levels[2] + "_costs", level=2
+    )
 
     invested_storage_capacity_costs = invested_storage_capacity.copy()
-    invested_storage_capacity_costs.index = invested_storage_capacity.reset_index(level=2, drop=True).index.map(
-        lambda x: (x[0].label, x[1].label if not isinstance(x[1], float) else x[1]))
-    invested_storage_capacity_costs = invested_storage_capacity_costs.multiply(ep_costs.reindex(invested_storage_capacity_costs.index))
+    invested_storage_capacity_costs.index = invested_storage_capacity.reset_index(
+        level=2, drop=True
+    ).index.map(
+        lambda x: (x[0].label, x[1].label if not isinstance(x[1], float) else x[1])
+    )
+    invested_storage_capacity_costs = invested_storage_capacity_costs.multiply(
+        ep_costs.reindex(invested_storage_capacity_costs.index)
+    )
     invested_storage_capacity_costs.index = invested_storage_capacity.index
     invested_storage_capacity_costs = invested_storage_capacity_costs.dropna()
-    invested_storage_capacity_costs.index = invested_storage_capacity_costs.index.set_levels(
-        invested_storage_capacity_costs.index.levels[2] + "_costs", level=2)
+    invested_storage_capacity_costs.index = (
+        invested_storage_capacity_costs.index.set_levels(
+            invested_storage_capacity_costs.index.levels[2] + "_costs", level=2
+        )
+    )
 
     # Calculate summed variable costs
     summed_variable_costs = get_summed_variable_costs(summed_flows, scalar_params)

--- a/oemoflex/model/postprocessing.py
+++ b/oemoflex/model/postprocessing.py
@@ -386,6 +386,17 @@ def get_summed_variable_costs(summed_flows, scalar_params):
     return summed_variable_costs
 
 
+def get_total_system_cost(*args):
+
+    all_costs = pd.concat(args)
+
+    index = pd.MultiIndex.from_tuples([("system", "total_system_cost")])
+
+    total_system_cost = pd.DataFrame({"var_value": [all_costs.sum()]}, index=index)
+
+    return total_system_cost
+
+
 def set_index_level(series, level, value):
     r"""
     Sets a value to a multiindex level. If the level does not exist, it
@@ -701,6 +712,13 @@ def run_postprocessing(es):
 
     summed_marginal_costs = get_outputs(summed_variable_costs)
 
+    total_system_cost = get_total_system_cost(
+        invested_capacity_costs,
+        invested_storage_capacity_costs,
+        summed_carrier_costs,
+        summed_marginal_costs,
+    )
+
     # # Get flows with emissions
     # carriers_with_emissions = 'ch4'
     #
@@ -755,12 +773,14 @@ def run_postprocessing(es):
 
     all_scalars = add_component_info(all_scalars)
 
-    all_scalars = sort_scalars(all_scalars)
-
     # Set index to string
     # TODO: Check if this can be done far earlier, also for performance reasons.
     # TODO: To do so, the information drawn from the components in add_component_info has
     # TODO: to be provided differently.
     all_scalars.index = all_scalars.index.map(lambda x: (x[0].label, x[1]))
+
+    all_scalars = pd.concat([all_scalars, total_system_cost], axis=0)
+
+    all_scalars = sort_scalars(all_scalars)
 
     return all_scalars

--- a/oemoflex/model/postprocessing.py
+++ b/oemoflex/model/postprocessing.py
@@ -656,6 +656,28 @@ def run_postprocessing(es):
 
         invested_storage_capacity = invest.loc[target_is_none]
 
+    ep_costs = filter_by_var_name(scalar_params, "investment_ep_costs")
+    ep_costs.index = ep_costs.reset_index(level=2, drop=True).index.map(
+        lambda x: (x[0].label, x[1].label if not isinstance(x[1], float) else x[1]))
+
+    invested_capacity_costs = invested_capacity.copy()
+    invested_capacity_costs.index = invested_capacity.reset_index(level=2, drop=True).index.map(
+        lambda x: (x[0].label, x[1].label if not isinstance(x[1], float) else x[1]))
+    invested_capacity_costs = invested_capacity_costs.multiply(ep_costs.reindex(invested_capacity_costs.index))
+    invested_capacity_costs.index = invested_capacity.index
+    invested_capacity_costs = invested_capacity_costs.dropna()
+    invested_capacity_costs.index = invested_capacity_costs.index.set_levels(
+        invested_capacity_costs.index.levels[2] + "_costs", level=2)
+
+    invested_storage_capacity_costs = invested_storage_capacity.copy()
+    invested_storage_capacity_costs.index = invested_storage_capacity.reset_index(level=2, drop=True).index.map(
+        lambda x: (x[0].label, x[1].label if not isinstance(x[1], float) else x[1]))
+    invested_storage_capacity_costs = invested_storage_capacity_costs.multiply(ep_costs.reindex(invested_storage_capacity_costs.index))
+    invested_storage_capacity_costs.index = invested_storage_capacity.index
+    invested_storage_capacity_costs = invested_storage_capacity_costs.dropna()
+    invested_storage_capacity_costs.index = invested_storage_capacity_costs.index.set_levels(
+        invested_storage_capacity_costs.index.levels[2] + "_costs", level=2)
+
     # Calculate summed variable costs
     summed_variable_costs = get_summed_variable_costs(summed_flows, scalar_params)
 
@@ -706,6 +728,8 @@ def run_postprocessing(es):
         to_from_capacity,
         invested_capacity,
         invested_storage_capacity,
+        invested_capacity_costs,
+        invested_storage_capacity_costs,
         summed_carrier_costs,
         summed_marginal_costs,
     ]

--- a/oemoflex/model/postprocessing.py
+++ b/oemoflex/model/postprocessing.py
@@ -668,36 +668,17 @@ def run_postprocessing(es):
         invested_storage_capacity = invest.loc[target_is_none]
 
     ep_costs = filter_by_var_name(scalar_params, "investment_ep_costs")
-    ep_costs.index = ep_costs.reset_index(level=2, drop=True).index.map(
-        lambda x: (x[0].label, x[1].label if not isinstance(x[1], float) else x[1])
-    )
 
-    invested_capacity_costs = invested_capacity.copy()
-    invested_capacity_costs.index = invested_capacity.reset_index(
-        level=2, drop=True
-    ).index.map(
-        lambda x: (x[0].label, x[1].label if not isinstance(x[1], float) else x[1])
+    invested_capacity_costs = multiply_var_with_param(
+        invested_capacity, ep_costs.unstack(2)["investment_ep_costs"]
     )
-    invested_capacity_costs = invested_capacity_costs.multiply(
-        ep_costs.reindex(invested_capacity_costs.index)
-    )
-    invested_capacity_costs.index = invested_capacity.index
-    invested_capacity_costs = invested_capacity_costs.dropna()
     invested_capacity_costs.index = invested_capacity_costs.index.set_levels(
         invested_capacity_costs.index.levels[2] + "_costs", level=2
     )
 
-    invested_storage_capacity_costs = invested_storage_capacity.copy()
-    invested_storage_capacity_costs.index = invested_storage_capacity.reset_index(
-        level=2, drop=True
-    ).index.map(
-        lambda x: (x[0].label, x[1].label if not isinstance(x[1], float) else x[1])
+    invested_storage_capacity_costs = multiply_var_with_param(
+        invested_storage_capacity, ep_costs.unstack(2)["investment_ep_costs"]
     )
-    invested_storage_capacity_costs = invested_storage_capacity_costs.multiply(
-        ep_costs.reindex(invested_storage_capacity_costs.index)
-    )
-    invested_storage_capacity_costs.index = invested_storage_capacity.index
-    invested_storage_capacity_costs = invested_storage_capacity_costs.dropna()
     invested_storage_capacity_costs.index = (
         invested_storage_capacity_costs.index.set_levels(
             invested_storage_capacity_costs.index.levels[2] + "_costs", level=2


### PR DESCRIPTION
Investment costs are calculated by multiplying capacities with ep_costs (from scalar_params).
Unfortunately, `pandas.Series` cannot multiplied by index directly as components differ (due to restoring, which creates multiple identifiers for same components). Therefore, much reindexing has to be done in order to multiply correctly.