### PR TITLE
Build EDP without link if it is None

### DIFF
--- a/oemoflex/model/datapackage.py
+++ b/oemoflex/model/datapackage.py
@@ -209,6 +209,9 @@ class EnergyDataPackage(DataFramePackage):
         component_attrs_update : dict
             Update with custom-defined components
         """
+        if links is None:
+            components.remove("electricity-transmission")
+
         data, rel_paths = create_default_data(
             select_regions=regions,
             select_links=links,


### PR DESCRIPTION
Resolves #68

With this PR it is now possible to build and optimize an energy system with `oemoflex` which does not contain any link.