### PR TITLE
Remove capacities from results

### DIFF
--- a/oemoflex/model/postprocessing.py
+++ b/oemoflex/model/postprocessing.py
@@ -622,19 +622,6 @@ def run_postprocessing(es):
         summed_flows_transmission, var_name="transmission_losses"
     )
 
-    # Collect existing (exogenous) capacity (units of power) and storage capacity (units of energy)
-    # Keep in mind - this has an index of the form (component, None).
-    # It is not attributed to a flow
-    capacity = filter_by_var_name(scalar_params, "capacity")
-
-    from_to_capacity = filter_by_var_name(scalar_params, "from_to_capacity")
-
-    to_from_capacity = filter_by_var_name(scalar_params, "to_from_capacity")
-
-    # Keep in mind - this has an index of the form (component, None).
-    # It is not attributed to a flow
-    storage_capacity = filter_by_var_name(scalar_params, "storage_capacity")
-
     # Collect invested (endogenous) capacity (units of power) and
     # storage capacity (units of energy)
 
@@ -720,10 +707,6 @@ def run_postprocessing(es):
         summed_flows,
         storage_losses,
         transmission_losses,
-        capacity,
-        storage_capacity,
-        from_to_capacity,
-        to_from_capacity,
         invested_capacity,
         invested_storage_capacity,
         invested_capacity_costs,

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "oemof.tabular @ git+https://git@github.com/oemof/oemof-tabular@dev#egg=oemof.tabular",
         "plotly",
         "frictionless",
+        "matplotlib",
     ],
     # black version is specified so that each contributor uses the same one
     extras_require={"dev": ["pytest", "black==20.8b1", "coverage", "flake8"]},

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "dynaconf",
         "pandas",
         "oemof.tabular @ git+https://git@github.com/oemof/oemof-tabular@dev#egg=oemof.tabular",
+        "plotly",
         "frictionless",
     ],
     # black version is specified so that each contributor uses the same one


### PR DESCRIPTION
Resolves #72 

With this PR `capacity`, `from_to_capacity`, `to_from_capacity` and `storage_capacity` appear no longer in the postprocessed results.