### PR TITLE
Restructure overview.rst

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -12,8 +12,12 @@ energy systems that can be optimized with oemof.solph. You want to focus on the 
 modeling: Find suitable data and make assumptions to build meaningful scenarios and interpret them.
 To support you with that, oemoflex helps you to:
 
-Define **schemas for tabular data packages** that describe energy systems. The schemas for different
-types of components are defined in
+
+Define schemas for tabular data packages
+========================================
+
+The schemas describe the energy systems and are defined for different
+types of components in
 `facade_attrs <https://github.com/rl-institut/oemoflex/tree/dev/oemoflex/model/facade_attrs>`_.
 The files `component_attrs.yml <https://github.com/rl-institut/oemoflex/blob/dev/oemoflex/model/component_attrs.yml>`_
 and `busses.yml <https://github.com/rl-institut/oemoflex/blob/dev/oemoflex/model/busses.yml>`_

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -19,13 +19,21 @@ The files `component_attrs.yml <https://github.com/rl-institut/oemoflex/blob/dev
 and `busses.yml <https://github.com/rl-institut/oemoflex/blob/dev/oemoflex/model/busses.yml>`_
 define the available components and busses.
 
-**Setup datapackages.** You can create data packages for an energy system by passing the lists of
+
+Setup datapackages
+==================
+
+You can create data packages for an energy system by passing the lists of
 regions, links, busses and components that you want to model to
 :meth:`EnergyDataPackage.setup_default <oemoflex.model.datapackage.EnergyDataPackage.setup_default>`.
 Custom-defined busses and components can be passed as dictionaries :attr:`bus_attrs_update` and
 :attr:`component_attrs_update`.
 
-**Infer metadata.** Metadata that describe the tables and their foreign key relations in form of a
+
+Infer metadata
+==============
+
+Metadata that describe the tables and their foreign key relations in form of a
 :file:`datapackage.json` are a requirement for oemof.tabular to load the datapackage as an
 :class:`oemof.solph.EnergySystem`. To infer metadata for an existing data package, use
 :meth:`EnergyDataPackage.infer_metadata <oemoflex.model.datapackage.EnergyDataPackage.infer_metadata>`.
@@ -34,7 +42,11 @@ Foreign key relations are defined in
 When adding custom-defined components and busses, a dictionary with :attr:`foreign_keys_update`
 can be passed.
 
-**Parametrize data packages.** Parametrize the EnergyDataPackage with
+
+Parametrize data packages
+=========================
+
+Parametrize the EnergyDataPackage with
 :meth:`EnergyDataPackage.parametrize <oemoflex.model.datapackage.EnergyDataPackage.parametrize>` to
 set the values of parameters for all components.
 
@@ -42,8 +54,16 @@ set the values of parameters for all components.
 
 .. TODO: Not implemented yet. **Create variations.** of existing EnergyDataPackages.
 
-**Postprocess results.** Results of an oemof.solph optimisation can be postprocessed and saved as
+
+Postprocess results
+===================
+
+Results of an oemof.solph optimisation can be postprocessed and saved as
 a :class:`ResultsDataPackage <oemoflex.model.datapackage.ResultsDataPackage>`.
 
-**Plot results.** Plot methods help to visualize and understand the results of a scenario. Read the
+
+Plot results
+============
+
+Plot methods help to visualize and understand the results of a scenario. Read the
 API documentation of :mod:`oemoflex.tools.plots <oemoflex.tools.plots>` for more details.


### PR DESCRIPTION
This PR adds paragraphs to the overview chapter, which can also be referenced in external documentation (e.g. `oemof-B3`).