### PR TITLE
Add clarification what if capacity of excess and shortage is empty

### DIFF
--- a/oemoflex/model/facade_attrs/excess.csv
+++ b/oemoflex/model/facade_attrs/excess.csv
@@ -5,6 +5,6 @@ type,str,n/a,Type
 carrier,str,n/a,Energy carrier
 tech,str,n/a,Technology
 bus,str,n/a,The bus this component is connected to
-capacity,float,MW,Maximum allowed excess
+capacity,float,MW,Maximum allowed excess which is set to None if left empty
 marginal_cost,float,Eur/MWh,Marginal cost
 input_parameters,dict,n/a,Optional parameters passed to oemof-solph's input flow

--- a/oemoflex/model/facade_attrs/shortage.csv
+++ b/oemoflex/model/facade_attrs/shortage.csv
@@ -5,6 +5,6 @@ type,str,n/a,Type
 carrier,str,n/a,Energy carrier
 tech,str,n/a,Technology
 bus,str,n/a,The bus this component is connected to
-capacity,float,MW,Maximum allowed shortage
+capacity,float,MW,Maximum allowed shortage which is set to None if left empty
 marginal_cost,float,Eur/MWh,Marginal cost
 output_parameters,dict,n/a,Optional parameters passed to oemof-solph's output flow


### PR DESCRIPTION
With this PR additional info is added concerning the attribute `capacity` of `excess` and `shortage` component:

If it is left empty it is set to None.