### PR TITLE
Fix/get config when installing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ setup(
     long_description=read("README.md"),
     packages=find_packages(),
     package_data={
+        "oemoflex.config": [
+            "settings.yml"
+        ],
         "oemoflex.model": [
             "*.yml",
             "*.csv",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_packages(),
     package_data={
         "oemoflex.config": [
-            "settings.yml"
+            "settings.yaml"
         ],
         "oemoflex.model": [
             "*.yml",


### PR DESCRIPTION
Include settings in package data and make config a proper module that can be found by `find_packages` in setup.py.