### PR TITLE
Fix/postprocessing pandas concat error

### DIFF
--- a/oemoflex/model/postprocessing.py
+++ b/oemoflex/model/postprocessing.py
@@ -820,10 +820,10 @@ def run_postprocessing(es):
     # TODO: Check if this can be done far earlier, also for performance reasons.
     # TODO: To do so, the information drawn from the components in add_component_info has
     # TODO: to be provided differently.
-    all_scalars.index = all_scalars.index.map(lambda x: (x[0].label, x[1]))
+    all_scalars_df.index = all_scalars_df.index.map(lambda x: (x[0].label, x[1]))
 
-    all_scalars = pd.concat([all_scalars, total_system_cost], axis=0)
+    all_scalars_df = pd.concat([all_scalars_df, total_system_cost], axis=0)
 
-    all_scalars = sort_scalars(all_scalars)
+    all_scalars_df = sort_scalars(all_scalars_df)
 
-    return all_scalars
+    return all_scalars_df

--- a/oemoflex/model/postprocessing.py
+++ b/oemoflex/model/postprocessing.py
@@ -801,9 +801,20 @@ def run_postprocessing(es):
     # did not work
     # Todo: To be further investigated
 
-    all_scalars = map_var_names(all_scalars)
+    # Index work-around - issues with concat and Multiindex
+    list(map(lambda series: series.rename("0", inplace=True), all_scalars))
+    all_scalars_reindexed = [s.reset_index() for s in all_scalars]
+    all_scalars_df_reindexed = pd.concat(
+        all_scalars_reindexed, ignore_index=True, axis=0
+    )
+    all_scalars_df = all_scalars_df_reindexed.set_index(
+        ["source", "target", "var_name"]
+    )
 
-    all_scalars = add_component_info(all_scalars)
+    # Map var_names
+    all_scalars_df = map_var_names(all_scalars_df)
+
+    all_scalars_df = add_component_info(all_scalars_df)
 
     # Set index to string
     # TODO: Check if this can be done far earlier, also for performance reasons.

--- a/oemoflex/model/postprocessing.py
+++ b/oemoflex/model/postprocessing.py
@@ -802,7 +802,7 @@ def run_postprocessing(es):
     # Todo: To be further investigated
 
     # Index work-around - issues with concat and Multiindex
-    all_scalars_reindexed = [s.rename("0").reset_index() for s in all_scalars]
+    all_scalars_reindexed = [s.rename("var_value").reset_index() for s in all_scalars]
     all_scalars_df_reindexed = pd.concat(
         all_scalars_reindexed, ignore_index=True, axis=0
     )

--- a/oemoflex/model/postprocessing.py
+++ b/oemoflex/model/postprocessing.py
@@ -802,8 +802,7 @@ def run_postprocessing(es):
     # Todo: To be further investigated
 
     # Index work-around - issues with concat and Multiindex
-    list(map(lambda series: series.rename("0", inplace=True), all_scalars))
-    all_scalars_reindexed = [s.reset_index() for s in all_scalars]
+    all_scalars_reindexed = [s.rename("0").reset_index() for s in all_scalars]
     all_scalars_df_reindexed = pd.concat(
         all_scalars_reindexed, ignore_index=True, axis=0
     )

--- a/oemoflex/model/postprocessing.py
+++ b/oemoflex/model/postprocessing.py
@@ -789,7 +789,17 @@ def run_postprocessing(es):
         summed_marginal_costs,
     ]
 
-    all_scalars = pd.concat(all_scalars, axis=0)
+    # all_scalars = pd.concat(all_scalars, axis=0)
+    # This does not work with the update from pandas==2.0.3 to pandas==2.2.1 because
+    # invested_capacity and invested_storage_capacity both have a TimeStamp as column name which
+    # results in a mix-up of the levels
+    # Fixing Approach:
+    # list(map(lambda series: series.rename('0', inplace=True), all_scalars))
+    # timestamp_variable = pd.to_datetime("2017-01-01 00:00:00")
+    # all_scalars = pd.concat(all_scalars, axis=0,
+    # keys=['source', 'target', 'var_name', '0', 0, 'var_value', timestamp_variable])
+    # did not work
+    # Todo: To be further investigated
 
     all_scalars = map_var_names(all_scalars)
 


### PR DESCRIPTION
Resolves

```
INFO - Restoring attributes will overwrite existing attributes.
Traceback (most recent call last):
  File "~/Schreibtisch/oemof-B3/scripts/postprocess.py", line 61, in <module>
    rdp = ResultsDataPackage.from_energysytem(es)
  File "~/anaconda3/envs/oemof-B3_desktop/lib/python3.10/site-packages/oemoflex/model/datapackage.py", line 320, in from_energysytem
    data, rel_paths = cls._get_results(cls, es)
  File "~/anaconda3/envs/oemof-B3_desktop/lib/python3.10/site-packages/oemoflex/model/datapackage.py", line 330, in _get_results
    data_scal, rel_paths_scal = self._get_scalars(self, es)
  File "~/anaconda3/envs/oemof-B3_desktop/lib/python3.10/site-packages/oemoflex/model/datapackage.py", line 405, in _get_scalars
    all_scalars = run_postprocessing(es)
  File "~/anaconda3/envs/oemof-B3_desktop/lib/python3.10/site-packages/oemoflex/model/postprocessing.py", line 809, in run_postprocessing
    all_scalars = map_var_names(all_scalars)
  File "~/anaconda3/envs/oemof-B3_desktop/lib/python3.10/site-packages/oemoflex/model/postprocessing.py", line 585, in map_var_names
    scalars.index = scalars.index.map(map_index)
  File "~/anaconda3/envs/oemof-B3_desktop/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 6491, in map
    new_values = self._map_values(mapper, na_action=na_action)
  File "~/anaconda3/envs/oemof-B3_desktop/lib/python3.10/site-packages/pandas/core/base.py", line 921, in _map_values
    return algorithms.map_array(arr, mapper, na_action=na_action, convert=convert)
  File "~/anaconda3/envs/oemof-B3_desktop/lib/python3.10/site-packages/pandas/core/algorithms.py", line 1743, in map_array
    return lib.map_infer(values, mapper, convert=convert)
  File "lib.pyx", line 2972, in pandas._libs.lib.map_infer
  File "~/anaconda3/envs/oemof-B3_desktop/lib/python3.10/site-packages/oemoflex/model/postprocessing.py", line 565, in map_index
    component_id = get_component_id(id)
  File "~/anaconda3/envs/oemof-B3_desktop/lib/python3.10/site-packages/oemoflex/model/postprocessing.py", line 522, in get_component_id
    component_id = get_component_id_in_tuple((id[0], id[1]))
  File "~/anaconda3/envs/oemof-B3_desktop/lib/python3.10/site-packages/oemoflex/model/postprocessing.py", line 170, in get_component_id_in_tuple
    return component_id
UnboundLocalError: local variable 'component_id' referenced before assignment
```

This errors originates [here](https://github.com/rl-institut/oemoflex/blob/8de4dfec8395efab526f0c98dfa5736f973b19a3/oemoflex/model/postprocessing.py#L792) with pandas==2.2.1. With pandas==2.0.3 it still worked.

The two Series [`invested_capacity` and `invested_storage_capacity`](https://github.com/rl-institut/oemoflex/blob/8de4dfec8395efab526f0c98dfa5736f973b19a3/oemoflex/model/postprocessing.py#L784-L785) have a TimeStamp as column name and hence in 'name' which mixes up the index order in the Dataframe created with the concat function.

Replacing it with `list(map(lambda series: series.rename('0', inplace=True), all_scalars))` did not make any difference and neither did

```
    timestamp_variable = pd.to_datetime("2017-01-01 00:00:00")
    all_scalars = pd.concat(all_scalars, axis=0, keys=['source', 'target', 'var_name', '0', 0, 'var_value', timestamp_variable])
    all_scalars = all_scalars.droplevel(0)
```

So for now, a workaround is implemented where the multi-index is written to a one-level/single-index and then retrieved from the single-index-string (with the multi-index in it) after concatenation.
