### PR TITLE
Fix Error 'Config validation error in build.os. Value build not found.'

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,11 @@ sphinx:
    configuration: docs/conf.py
 
 # Optionally set the version of Python and requirements required to build your docs
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"
+
 python:
    version: "3.7"
    install:


### PR DESCRIPTION
Building docs errors out:

```
Build # 23637095
[latest](https://readthedocs.org/dashboard/oemoflex/version/latest/edit/)
Build fehlgeschlagen
Error
Config validation error in build.os. Value build not found.

git clone --depth 1 https://github.com/rl-institut/oemoflex .
git fetch origin --force --prune --prune-tags --depth 50 refs/heads/dev:refs/remotes/origin/dev
git checkout --force origin/dev
git clean -d -f -f
```

With this PR the solution proposed according to issue https://github.com/readthedocs/readthedocs.org/issues/11173
-> https://docs.readthedocs.io/en/stable/config-file/v2.html