### PR TITLE
Make oemoflex independent of oemof.tabular

### DIFF
--- a/oemoflex/facades.py
+++ b/oemoflex/facades.py
@@ -21,7 +21,7 @@ class Source(solph.components.Source):
         self.tech = kwargs.get("tech", None)
 
 
-class Transformer(solph.components.Transformer):
+class Transformer(solph.components.Converter):
     r"""
     Supplement Transformer with carrier and tech properties to work with labeling in postprocessing
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         "pyyaml",
         "dynaconf",
         "pandas",
-        "oemof.tabular==0.0.5",
         "plotly",
         "frictionless",
         "matplotlib",

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "pyyaml",
         "dynaconf",
         "pandas",
+        "oemof.tabular",
         "plotly",
         "frictionless",
         "matplotlib",


### PR DESCRIPTION
Also adapted oemoflex for oemof.solph > v0.5.1 by renaming `Transformer` to `Converter`